### PR TITLE
Exclude system.profile collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Install latest development version:
     cd mongo-oplog-backup
     rake install
 
+### Dependencies
+
+The following mongoDB tools are required:
+ * mongo shell
+ * mongodump (>= 3.0)
+
 ## Usage
 
 To backup from localhost to the `mybackup` directory.

--- a/lib/mongo_oplog_backup/config.rb
+++ b/lib/mongo_oplog_backup/config.rb
@@ -62,7 +62,7 @@ module MongoOplogBackup
     end
 
     def mongodump(*args)
-      exec(['mongodump'] + command_line_options + args.flatten)
+      exec(['mongodump'] + command_line_options + ['--excludeCollection', 'system.profile'] + args.flatten)
     end
 
     def mongo(db, script)


### PR DESCRIPTION
Given a backup user with the `backup` role (and no other relevant read access), if database profiling is enabled, a `mongo-oplog-dump --full` fails on the `system.profile` collection. The built-in `backup` role has read access to only a few system collections.

However, in MongoDB 3.0, `mongodump` allows excluding collections, which this PR uses to circumvent the above issue.

This is backwards incompatible with `mongodump` < 3.0.