### PR TITLE
Update backup.rb

### DIFF
--- a/lib/mongo_oplog_backup/backup.rb
+++ b/lib/mongo_oplog_backup/backup.rb
@@ -38,7 +38,7 @@ module MongoOplogBackup
       start_at = options[:start] || BSON::Timestamp.from_json(backup_state['position'])
       raise ArgumentError, ":start is required" unless start_at
 
-      query = ['--query', "{ts : { $gte : { $timestamp : { t : #{start_at.seconds}, i : #{start_at.increment} } } }}"]
+      query = ['--query', "{\"ts\" : { \"$gte\" : { \"$timestamp\" : { \"t\" : #{start_at.seconds}, \"i\" : #{start_at.increment} } } }}"]
 
       dump_args = ['--out', config.oplog_dump_folder, '--db', 'local', '--collection', 'oplog.rs']
       dump_args += query


### PR DESCRIPTION
mongodb 4.2 output error: Failed: error parsing query as Extended JSON: invalid JSON input; change "{ts : { $gte: { $timestamp: { t : #{start_at.seconds}, i : #{start_at.increment} } } }}"    to     "{\"ts\" : { \"$gte\" : { \"$timestamp\" : { \"t\" : #{start_at.seconds}, \"i\" : #{start_at.increment} } } }}" ,   is work